### PR TITLE
Add additional SPF terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ module {
 
   dmarc_rua = ["dmarc_rua@example.net"]
   dmarc_ruf = ["dmarc_ruf@example.net", "dmarc_ruf@example.org"]
+  spf_terms = ["-ip4:192.0.2.0/24", "+ip6:2001:DB8::/32"]
 }
 ```
 
@@ -46,6 +47,7 @@ module {
 | zone_name | Cloudflare Zone Name | `string` | yes |
 | dmarc_rua | Email addresses for DMARC Aggregate reports (excluding `mailto:`), at least one and contains the `@` symbol. | `list(string)` | yes |
 | dmarc_rua | Email addresses for DMARC Failure (or Forensic) reports (excluding `mailto:`), at least one and contains the `@` symbol. | `list(string)` | yes |
+| spf_terms | Additional SPF terms to include, `include:spf.messagingengine.com -all` are already provided. | `list(string)` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "cloudflare_record" "dkim3" {
 resource "cloudflare_record" "spf" {
   zone_id = var.zone_id
   name    = "@"
-  value   = "v=spf1 include:spf.messagingengine.com -all"
+  value   = "v=spf1 ${join(" ", concat(["include:spf.messagingengine.com"], var.spf_terms, ["-all"]))}"
   type    = "TXT"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,14 @@ variable "dmarc_ruf" {
     error_message = "Must be a valid email address."
   }
 }
+
+variable "spf_terms" {
+  type        = list(string)
+  description = "Additional SPF terms to include, `include:spf.messagingengine.com -all` are already provided"
+  default     = []
+
+  validation {
+    condition     = can([for term in var.spf_terms : regex("^(\\+|-|\\?|~)?(all|include|a|mx|ip4|ip6|exists)", term)])
+    error_message = "SPF term must start with a valid qualifier (optional) or mechanism."
+  }
+}


### PR DESCRIPTION
Closes #2

Adds:
 - New variable `spf_terms` to specify additional SPF terms which must start with a valid qualifier or mechanism.