### PR TITLE
Add MTA-STS through terraform-cloudflare-mta-sts dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # terraform-cloudflare-fastmail-email
 
-MX, SPF, DKIM and DMARC records for email hosted by Fastmail.
+MX, SPF, DKIM and DMARC records with MTA-STS policy (via [terraform-cloudflare-mta-sts](https://github.com/rsclarke/terraform-cloudflare-mta-sts)) for email hosted by Fastmail.
 
-This creates `cloudflare_record` resources for MX, SPF, DKIM and DMARC of the given `zone_id` suitable for [fastmail.com](https://fastmail.com).
+This creates `cloudflare_record` resources for MX, SPF, DKIM, DMARC and MTA-STS of the given `zone_id` suitable for [fastmail.com](https://fastmail.com).  A Cloudflare Worker as part of the [terraform-cloudflare-mta-sts](https://github.com/rsclarke/terraform-cloudflare-mta-sts) dependency serves the MTA-STS policy.
 
-The SPF policy includes Fastmail by default and rejects all others (`-all`).  The DMARC policies is set to reject and you must provide an email address for DMARC Aggregate and Failure reports through the `dmarc_rua` and `dmarc_ruf` variables respectively.
+The SPF policy includes Fastmail by default and rejects all others (`-all`), additional terms can be specified using the `spf_terms` variable.  
+
+The DMARC policy is set to reject and you must provide an email address for DMARC Aggregate and Failure reports through the `dmarc_rua` and `dmarc_ruf` variables respectively.  Similarly, a TLS aggregate reporting location (`mailto:` or `https:`) must be specified in the `tlsrpt_rua` variable.
 
 ## Usage
 
@@ -23,6 +25,11 @@ module {
   dmarc_rua = ["dmarc_rua@example.net"]
   dmarc_ruf = ["dmarc_ruf@example.net", "dmarc_ruf@example.org"]
   spf_terms = ["-ip4:192.0.2.0/24", "+ip6:2001:DB8::/32"]
+
+  mta_sts_mode    = "enforce"
+  mta_sts_mx      = ["mx.example.net"]
+  mta_sts_max_age = 604800
+  tlsrpt_rua      = ["mailto:tls_report@example.org", "https://example.org/mta-sts/report"]
 }
 ```
 
@@ -48,6 +55,10 @@ module {
 | dmarc_rua | Email addresses for DMARC Aggregate reports (excluding `mailto:`), at least one and contains the `@` symbol. | `list(string)` | yes |
 | dmarc_rua | Email addresses for DMARC Failure (or Forensic) reports (excluding `mailto:`), at least one and contains the `@` symbol. | `list(string)` | yes |
 | spf_terms | Additional SPF terms to include, `include:spf.messagingengine.com -all` are already provided. | `list(string)` | no |
+| mta_sts_mode | Sending MTA policy application, [rfc8461#section-5](https://tools.ietf.org/html/rfc8461#section-5).  Default `testing` | `string` | no |
+| mta_sts_mx | List of additional permitted MX hosts for the MTA STS policy. This does not create the resources for. | `list(string)` | no |
+| mta_sts_max_age | Maximum lifetime of the MTA STS policy in seconds, up to 31557600, defaults to 604800 (1 week) | `number` | no |
+| tlsrpt_rua | Locations to which MTA STS aggregate reports about policy violations should be sent, either `mailto:` or `https:` schema. | `list(string)` | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -48,3 +48,16 @@ resource "cloudflare_record" "dmarc" {
   value   = "v=DMARC1; p=reject; rua=mailto:${join(",mailto:", var.dmarc_rua)}; ruf=mailto:${join(",mailto:", var.dmarc_ruf)}; fo=1:d:s"
   type    = "TXT"
 }
+
+module "mta_sts" {
+  source  = "rsclarke/mta-sts/cloudflare"
+  version = "~> 1.0.0"
+
+  zone_id   = var.zone_id
+  zone_name = var.zone_name
+
+  mode    = var.mta_sts_mode
+  mx      = concat([cloudflare_record.mx1.value, cloudflare_record.mx2.value], var.mta_sts_mx)
+  max_age = var.mta_sts_max_age
+  rua     = var.tlsrpt_rua
+}

--- a/variables.tf
+++ b/variables.tf
@@ -48,3 +48,51 @@ variable "spf_terms" {
     error_message = "SPF term must start with a valid qualifier (optional) or mechanism."
   }
 }
+
+variable "mta_sts_mode" {
+  type        = string
+  default     = "testing"
+  description = "Sending MTA policy application, https://tools.ietf.org/html/rfc8461#section-5"
+
+  validation {
+    condition     = contains(["enforce", "testing", "none"], var.mta_sts_mode)
+    error_message = "Only `enforce` `testing` or `none` is valid."
+  }
+}
+
+variable "mta_sts_mx" {
+  type        = list(string)
+  default     = []
+  description = "List of additional permitted MX hosts for the MTA STS policy. This does not create the resources for."
+}
+
+variable "mta_sts_max_age" {
+  type        = number
+  default     = 604800 # 1 week
+  description = "Maximum lifetime of the MTA STS policy in seconds, up to 31557600, defaults to 604800 (1 week)"
+
+  validation {
+    condition     = var.mta_sts_max_age >= 0
+    error_message = "Policy validity time must be positive."
+  }
+
+  validation {
+    condition     = var.mta_sts_max_age <= 31557600
+    error_message = "Policy validity time must be less than 1 year (31557600 seconds)."
+  }
+}
+
+variable "tlsrpt_rua" {
+  type        = list(string)
+  description = "Locations to which MTA STS aggregate reports about policy violations should be sent, either `mailto:` or `https:` schema."
+
+  validation {
+    condition     = length(var.tlsrpt_rua) != 0
+    error_message = "At least one `mailto:` or `https:` endpoint provided."
+  }
+
+  validation {
+    condition     = can([for loc in var.tlsrpt_rua : regex("^(mailto|https):", loc)])
+    error_message = "Locations must start with either the `mailto: or `https` schema."
+  }
+}


### PR DESCRIPTION
Adds MTA-STS support through [terraform-cloudflare-mta-sts](https://github.com/rsclarke/terraform-cloudflare-mta-sts) dependency.

Users are now required to specify the `tlsrpt_rua` variable causing a breaking change.  By default the policy will be in testing mode with a 1 week max age.  This policy is served via a Cloudflare Worker and namespace, likely to fit within the free tier.