### PR TITLE
chore: add dependabot configuration for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "08:00"
+      timezone: "Australia/Perth"


### PR DESCRIPTION
Adds a Dependabot configuration to automatically check for GitHub Actions updates on a weekly schedule (Fridays at 08:00 AWST).

- Add `.github/dependabot.yml` with weekly GitHub Actions update schedule